### PR TITLE
chore: Fix snapshot updater

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -4,13 +4,13 @@ on:
   workflow_run:
     workflows: [build]
     types: [completed]
-    branches: [github-actions/upgrade-main]
+    #branches: [github-actions/upgrade-main]
 
 jobs:
   on-failure:
     runs-on: ubuntu-latest
     container:
-      image: jsii/superchain:1-buster-slim-node14
+      image: jsii/superchain:1-buster-slim-node16
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - name: Checkout
@@ -77,7 +77,7 @@ jobs:
             ------
 
             *Automatically created by projen via the "upgrade-snapshot" workflow*
-          branch: github-actions/upgrade-snapshot
+          branch: ${{ github.event.workflow_run.head_branch }}-upgrade-snapshot
           title: "chore(deps): update snapshot for dependencies upgrade"
           body: |-
             Update snapshot. See details in [workflow run].


### PR DESCRIPTION
And make it work on all branches.

The fix was Node 16.