### PR TITLE
chore: Future-proof tests

### DIFF
--- a/test/default.integ.snapshot/RDS-Sanitized-Snapshotter-RDS.assets.json
+++ b/test/default.integ.snapshot/RDS-Sanitized-Snapshotter-RDS.assets.json
@@ -1,7 +1,7 @@
 {
   "version": "32.0.0",
   "files": {
-    "3ef7781e90eef0635b701eee0dc89ef27fa21482e2e661810f0a4648d2afaf7f": {
+    "43ed48878c85e3ce0324881d365f12acd6963f302748e21cd1257a713163350b": {
       "source": {
         "path": "RDS-Sanitized-Snapshotter-RDS.template.json",
         "packaging": "file"
@@ -9,7 +9,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3ef7781e90eef0635b701eee0dc89ef27fa21482e2e661810f0a4648d2afaf7f.json",
+          "objectKey": "43ed48878c85e3ce0324881d365f12acd6963f302748e21cd1257a713163350b.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/RDS-Sanitized-Snapshotter-RDS.template.json
+++ b/test/default.integ.snapshot/RDS-Sanitized-Snapshotter-RDS.template.json
@@ -78,7 +78,6 @@
     },
     "DeleteAutomatedBackups": true,
     "Engine": "mysql",
-    "EngineVersion": "8.0",
     "MasterUsername": {
      "Fn::Join": [
       "",
@@ -187,12 +186,10 @@
    "Properties": {
     "BackupRetentionPeriod": 1,
     "CopyTagsToSnapshot": true,
-    "DBClusterParameterGroupName": "default.aurora-mysql8.0",
     "DBSubnetGroupName": {
      "Ref": "MySQLClusterSubnets30A4ABD4"
     },
     "Engine": "aurora-mysql",
-    "EngineVersion": "8.0.mysql_aurora.3.05.0",
     "MasterUsername": {
      "Fn::Join": [
       "",
@@ -356,7 +353,6 @@
     },
     "DeleteAutomatedBackups": true,
     "Engine": "postgres",
-    "EngineVersion": "13",
     "KmsKeyId": {
      "Fn::GetAtt": [
       "Key961B73FD",
@@ -472,12 +468,10 @@
    "Properties": {
     "BackupRetentionPeriod": 1,
     "CopyTagsToSnapshot": true,
-    "DBClusterParameterGroupName": "default.aurora-postgresql13",
     "DBSubnetGroupName": {
      "Ref": "PostgresClusterSubnetsFC10D676"
     },
     "Engine": "aurora-postgresql",
-    "EngineVersion": "13.4",
     "KmsKeyId": {
      "Fn::GetAtt": [
       "Key961B73FD",

--- a/test/default.integ.snapshot/RDS-Sanitized-Snapshotter-Test.assets.json
+++ b/test/default.integ.snapshot/RDS-Sanitized-Snapshotter-Test.assets.json
@@ -53,7 +53,7 @@
         }
       }
     },
-    "9081f8c54eb5f9ecf144aac5402d28febba41fdc1f190565a3b2b752512a0393": {
+    "a301752ccc480328b97e28491cc71fcdb86fcb830116f446552af776ff464fed": {
       "source": {
         "path": "RDS-Sanitized-Snapshotter-Test.template.json",
         "packaging": "file"
@@ -61,7 +61,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "9081f8c54eb5f9ecf144aac5402d28febba41fdc1f190565a3b2b752512a0393.json",
+          "objectKey": "a301752ccc480328b97e28491cc71fcdb86fcb830116f446552af776ff464fed.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/RDS-Sanitized-Snapshotter-Test.template.json
+++ b/test/default.integ.snapshot/RDS-Sanitized-Snapshotter-Test.template.json
@@ -924,7 +924,7 @@
      "Fn::Join": [
       "",
       [
-       "{\"StartAt\":\"framework-isComplete-task\",\"States\":{\"framework-isComplete-task\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"States.ALL\"],\"IntervalSeconds\":5,\"MaxAttempts\":360,\"BackoffRate\":1}],\"Catch\":[{\"ErrorEquals\":[\"States.ALL\"],\"Next\":\"framework-onTimeout-task\"}],\"Type\":\"Task\",\"Resource\":\"",
+       "{\"StartAt\":\"framework-isComplete-task\",\"States\":{\"framework-isComplete-task\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"States.ALL\"],\"IntervalSeconds\":5,\"MaxAttempts\":708,\"BackoffRate\":1}],\"Catch\":[{\"ErrorEquals\":[\"States.ALL\"],\"Next\":\"framework-onTimeout-task\"}],\"Type\":\"Task\",\"Resource\":\"",
        {
         "Fn::GetAtt": [
          "ProviderframeworkisComplete26D7B0CB",


### PR DESCRIPTION
Specific engine versions always go out-of-date. Using unversioned engines doesn't work because CDK defaults to some weird parameter group version which doesn't match. We have to override CDK and remove the parameter group.

Fixes #